### PR TITLE
Add support for required_engine field

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -783,6 +783,15 @@ def validate_prompt(prompt):
                 "extra_info": {}
             }
             return (False, error, [], [])
+        
+        if hasattr(class_, 'REQUIRED_ENGINE') and class_.REQUIRED_ENGINE and class_.REQUIRED_ENGINE != 'comfyui':
+            error = {
+                "type": "invalid_prompt",
+                "message": f"Cannot execute because node {class_type} requires the {class_.REQUIRED_ENGINE} engine.",
+                "details": f"Node ID '#{x}'",
+                "extra_info": {"node_id": x},
+            }
+            return (False, error, [], [])
 
         if hasattr(class_, 'OUTPUT_NODE') and class_.OUTPUT_NODE is True:
             outputs.add(x)

--- a/server.py
+++ b/server.py
@@ -546,6 +546,7 @@ class PromptServer():
             info['description'] = obj_class.DESCRIPTION if hasattr(obj_class,'DESCRIPTION') else ''
             info['python_module'] = getattr(obj_class, "RELATIVE_PYTHON_MODULE", "nodes")
             info['category'] = 'sd'
+            info['required_engine'] = obj_class.REQUIRED_ENGINE if hasattr(obj_class, 'REQUIRED_ENGINE') else None
             if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
                 info['output_node'] = True
             else:


### PR DESCRIPTION
Adds support for `REQUIRED_ENGINE` in nodes when generating node_info as well as a validation step to prevent execution of nodes meant for another engine